### PR TITLE
Send heartbeats messages without waiting for TCP buffer or reconnecting a node.

### DIFF
--- a/src/aten_sink.erl
+++ b/src/aten_sink.erl
@@ -38,14 +38,7 @@ get_failure_probabilities() ->
 beat(DestNode) ->
     Dest = {?MODULE, DestNode},
     Msg = {hb, node()},
-    case erlang:send(Dest, {'$gen_cast', Msg}, [noconnect]) of
-        noconnect ->
-            % we don't want to hold up the messages for the other nodes
-            _ = spawn(fun () -> gen_server:cast(Dest, Msg) end),
-            ok;
-        ok ->
-            ok
-    end.
+    erlang:send(Dest, {'$gen_cast', Msg}, [noconnect, nosuspend]).
 
 %%%===================================================================
 %%% gen_server callbacks

--- a/src/aten_sink.erl
+++ b/src/aten_sink.erl
@@ -38,7 +38,8 @@ get_failure_probabilities() ->
 beat(DestNode) ->
     Dest = {?MODULE, DestNode},
     Msg = {hb, node()},
-    erlang:send(Dest, {'$gen_cast', Msg}, [noconnect, nosuspend]).
+    _ = erlang:send(Dest, {'$gen_cast', Msg}, [noconnect, nosuspend]),
+    ok.
 
 %%%===================================================================
 %%% gen_server callbacks


### PR DESCRIPTION
Fixes #2 

We don't want a full TCP buffer to suspend a heartbeat process, because there
can be other nodes waiting for heartbeats.
We send messages to all connected nodes and should not reconnect.

Protocol expects that heartbeats can be lost, so we sacrifice consistency
for constant sending progress.