### PR TITLE
make rebar3_hex a project_plugin instead of a regular plugin

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {minimum_otp_vsn, "22.3"}.
 {erl_opts, [debug_info]}.
 {deps, []}.
-{plugins, [rebar3_hex]}.
+{project_plugins, [rebar3_hex]}.
 {profiles,
  [{test, [{deps, [meck, proper]}]}]
 }.


### PR DESCRIPTION
`project_plugins` only get pulled in when you are working on that particular project at the top level. `rebar3_hex` should either be one of those or in the global rebar3 config, `~/.config/rebar3/rebar.config` so that it isn't pulled in when the app is used as a dependency.