### PR TITLE
add missing spec for aten:init/1

### DIFF
--- a/src/aten_detect.erl
+++ b/src/aten_detect.erl
@@ -27,6 +27,7 @@
 
 -export_type([state/0]).
 
+-spec init(number()) -> state().
 init(Factor) ->
     #state{factor = Factor}.
 


### PR DESCRIPTION
## Proposed Changes

Add missing spec to aten_detect:init/1. Without the spec, using this library from an external project will cause a dialyzer error, because the inferred init return type does not match the opaque type.

Example call (elixir syntax):

```
state = :aten_detect.init(1)
_fail_prob = :aten_detect.get_failure_probability(state)
```

Dializer error:

```
lib/a.ex:6:no_return
Function hello/0 has no local return.
________________________________________________________________________________
lib/a.ex:8:call_without_opaque
Function call without opaqueness type mismatch.

Call does not have expected opaque term of type :aten_detect.state() in the 1st position.

:aten_detect.get_failure_probability(_state :: {:state, :undefined, :array.array(_), 0, 1000, number()})
```

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Not applicable
