### PR TITLE
Avoid double notifying on node termination.

### DIFF
--- a/src/aten.erl
+++ b/src/aten.erl
@@ -10,23 +10,19 @@
          start/0,
          register/1,
          unregister/1
-         ]).
-
--export_type([
-              ]).
-
+        ]).
 
 start() ->
     application:ensure_all_started(aten).
 
--spec register(node()) -> ok.
+-spec register(node()) -> ok | ignore.
+register(Node) when Node == node() ->
+    ignore;
 register(Node) ->
     aten_detector:register(Node).
 
--spec unregister(node()) -> ok.
+-spec unregister(node()) -> ok | ignore.
+unregister(Node) when Node == node() ->
+    ignore;
 unregister(Node) ->
     aten_detector:unregister(Node).
-
--ifdef(TEST).
--include_lib("eunit/include/eunit.hrl").
--endif.

--- a/src/aten_detector.erl
+++ b/src/aten_detector.erl
@@ -157,10 +157,18 @@ analyse_one(_Curr, _Prev, _Thresh) ->
     no_change.
 
 analyse(Curr, Prev, Thresh) ->
-    Down0 = maps:fold(fun (N, _S, Acc) ->
+    Down0 = maps:fold(fun (N, Sample, Acc) ->
                               case maps:get(N, Curr, undefined) of
                                   undefined ->
-                                      [N | Acc];
+                                      case Sample >= Thresh of
+                                          true ->
+                                              %% already down
+                                              %% this should already have been
+                                              %% been notified
+                                              Acc;
+                                          _ ->
+                                              [N | Acc]
+                                      end;
                                   _ ->
                                       Acc
                               end

--- a/src/aten_sink.erl
+++ b/src/aten_sink.erl
@@ -8,8 +8,6 @@
 
 -behaviour(gen_server).
 
--include_lib("kernel/include/logger.hrl").
-
 %% API functions
 -export([start_link/0,
          get_failure_probabilities/0,


### PR DESCRIPTION
When a node was terminated aten would sometimes send two notifications to registered listeners. One when it detected the node as not responding and one next interval when it detected it as gone.

This adds a check for gone case to see if the node has already been detected as down and only sends a down notification in this scenario if the prior state is not down.

Also return `ignore` if trying to monitor the current node.
