### PR TITLE
Use monotonic time instead of erlang:system_time/1

### DIFF
--- a/src/aten_detect.erl
+++ b/src/aten_detect.erl
@@ -68,9 +68,7 @@ failure_prob_at(At, #state{freshness = F,
     SmallNum / max(1, TotNum). % avoid div/0
 
 ts() ->
-    % TODO: should we use erlang monotonic time instead?
-    % It probably doesn't matter
-    erlang:system_time(microsecond).
+    erlang:monotonic_time(microsecond).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").


### PR DESCRIPTION
It is the right thing to do.